### PR TITLE
Corrected includes

### DIFF
--- a/sgv2-filter.meta.js
+++ b/sgv2-filter.meta.js
@@ -7,7 +7,7 @@
 // @include     http://www.steamgifts.com/user/*
 // @downloadURL https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.user.js
 // @updateURL   https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.meta.js
-// @version     0.4.2-DEV
+// @version     0.4.3-DEV
 // @grant       GM_getValue
 // @grant       GM_setValue
 // ==/UserScript==

--- a/sgv2-filter.meta.js
+++ b/sgv2-filter.meta.js
@@ -3,7 +3,8 @@
 // @namespace   https://github.com/GarionCZ/sgv2-filter
 // @description Giveaway filter for SteamGifts v2
 // @author      Garion
-// @include     http://www.steamgifts.com/*
+// @include     http://www.steamgifts.com/giveaways*
+// @include     http://www.steamgifts.com/user/*
 // @downloadURL https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.user.js
 // @updateURL   https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.meta.js
 // @version     0.4.2-DEV

--- a/sgv2-filter.meta.js
+++ b/sgv2-filter.meta.js
@@ -3,6 +3,7 @@
 // @namespace   https://github.com/GarionCZ/sgv2-filter
 // @description Giveaway filter for SteamGifts v2
 // @author      Garion
+// @include     http://www.steamgifts.com/
 // @include     http://www.steamgifts.com/giveaways*
 // @include     http://www.steamgifts.com/user/*
 // @downloadURL https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.user.js

--- a/sgv2-filter.user.js
+++ b/sgv2-filter.user.js
@@ -3,6 +3,7 @@
 // @namespace   https://github.com/GarionCZ/sgv2-filter
 // @description Giveaway filter for SteamGifts v2
 // @author      Garion
+// @include     http://www.steamgifts.com/
 // @include     http://www.steamgifts.com/giveaways*
 // @include     http://www.steamgifts.com/user/*
 // @downloadURL https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.user.js

--- a/sgv2-filter.user.js
+++ b/sgv2-filter.user.js
@@ -3,10 +3,11 @@
 // @namespace   https://github.com/GarionCZ/sgv2-filter
 // @description Giveaway filter for SteamGifts v2
 // @author      Garion
-// @include     http://www.steamgifts.com/*
+// @include     http://www.steamgifts.com/giveaways*
+// @include     http://www.steamgifts.com/user/*
 // @downloadURL https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.user.js
 // @updateURL   https://github.com/GarionCZ/sgv2-filter/raw/master/sgv2-filter.meta.js
-// @version     0.4.2-DEV
+// @version     0.4.3-DEV
 // @grant       GM_getValue
 // @grant       GM_setValue
 // ==/UserScript==


### PR DESCRIPTION
Corrected the includes to only activate the script on giveaway overview pages and user profiles. Formerly the filter was shown on giveaway pages.
